### PR TITLE
Remove wiimote dep

### DIFF
--- a/phoenix.repos
+++ b/phoenix.repos
@@ -7,7 +7,3 @@ repositories:
       type: git 
       url: git@github.com:iscumd/twist_to_ackermann.git
       version: master
-    wii_wheel:
-      type: git
-      url: git@github.com:andyblarblar/ros2_wii_wheel.git
-      version: master


### PR DESCRIPTION
Wiimote keeps failing builds and it doesn't seem to be included for any other use than launching seperately from the package anyhow, so it's probobly best we remove it from the main repo to simplify things.

Opening this PR so you have a chance to double check if that blows something up.