### PR TITLE
Fixed NASCAR phoenix

### DIFF
--- a/phoenix_description/urdf/phoenix.urdf
+++ b/phoenix_description/urdf/phoenix.urdf
@@ -328,9 +328,8 @@
       <wheel_separation>0.94</wheel_separation>
       <wheel_radius>0.12065</wheel_radius>
       <odom_publish_frequency>20</odom_publish_frequency>
-      <!-- TODO add wheelbase -->
 
-      <min_velocity>0</min_velocity>
+      <min_velocity>-13</min_velocity>
       <max_velocity>13</max_velocity>
       <min_acceleration>-5</min_acceleration>
       <max_acceleration>10</max_acceleration>

--- a/phoenix_description/urdf/phoenix.urdf
+++ b/phoenix_description/urdf/phoenix.urdf
@@ -328,6 +328,8 @@
       <wheel_separation>0.94</wheel_separation>
       <wheel_radius>0.12065</wheel_radius>
       <odom_publish_frequency>20</odom_publish_frequency>
+      <wheel_base>1.0</wheel_base>
+      <kingpin_width>1.2954</kingpin_width>
 
       <min_velocity>-13</min_velocity>
       <max_velocity>13</max_velocity>


### PR DESCRIPTION
Closes #11 

Fix was to change phoenix's minimum velocity to a value below 0. Were pretty sure this is because the <min_velocity> tag in the URDF applies to both linear and angular velocity so with no negative angular velocity phoenix isn't able to turn right